### PR TITLE
Update running-locust-docker.rst

### DIFF
--- a/docs/running-locust-docker.rst
+++ b/docs/running-locust-docker.rst
@@ -27,11 +27,12 @@ The above compose configuration could be used to start a master node and 4 worke
 Use docker image as a base image
 ================================
 
-It's very common to have test scripts that rely on third party python packages. In those cases you can use the
-official Locust docker image as a base image::
+It's very common to have test scripts that rely on third party python packages. In those cases you can add the package installation command in the official Locust Dockerfile and build it:
 
-    FROM locustio/locust
-    RUN pip3 install some-python-package
+    FROM python:3.8
+    COPY . /build
+    RUN cd /build && pip install . && pip install some-python-package && rm -rf /build
+    ...
 
 
 Running a distributed load test on Kubernetes


### PR DESCRIPTION
The section "Use docker image as a base image" is wrong by directly adding RUN pip3 install XX after the base image. It will cause module import error in docker run because packages imported before installed.
The correct way is to add the installation command with other python packages installation in the locust Dockerfile or any place before the ENTRYPOINT.

    FROM python:3.8
    COPY . /build
    RUN cd /build && pip install . && pip install some-python-package && rm -rf /build
    ...